### PR TITLE
Feat: kernal install changes

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -32,12 +32,15 @@ rm -rf ~/rhino-config
 
 # If the user has selected the option to install the mainline kernel, install it onto the system.
 if [[ -f "$HOME/.rhino/config/mainline" ]]; then
-  cd ~/rhinoupdate/kernel/
-  wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
-  wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705_5.17.5-051705.202204271406_all.deb
-  wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-image-unsigned-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
-  wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-modules-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
-  sudo apt install ./*.deb
+  if [[ ! -f "$HOME/.rhino/config/5.17.5" ]]; then
+    cd ~/rhinoupdate/kernel/
+    wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
+    wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-headers-5.17.5-051705_5.17.5-051705.202204271406_all.deb
+    wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-image-unsigned-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
+    wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.5/amd64/linux-modules-5.17.5-051705-generic_5.17.5-051705.202204271406_amd64.deb
+    sudo apt install ./*.deb
+    : > "$HOME/.rhino/config/5.17.5"
+  fi
 fi
 
 # If snapd is installed.
@@ -61,5 +64,4 @@ fi
 
 # Allow the user to know that the upgrade has completed.
 echo "---
-The upgrade has been completed. Please reboot your system to see the changes.
----"
+The upgrade has been completed. Please reboot your system to see the changes.---"


### PR DESCRIPTION
This will hopefully change the way the kernal install functions to check for a file created named 5.17.5 which will be created in the config folder after the first kernal install. This way when going to update again it will check for the 5.17.5 file and if it is there the kernal will not install again as it is not necessary to do every single update